### PR TITLE
Ajout minishell.h, mod gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+main.c

--- a/minishell.h
+++ b/minishell.h
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   minishell.h                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nchennaf <nchennaf@student.42lausanne.c    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/07/22 13:25:30 by nchennaf          #+#    #+#             */
+/*   Updated: 2022/07/22 13:54:52 by nchennaf         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef MINISHELL_H
+# define MINISHELL_H
+
+# include <unistd.h>
+# include <stdio.h>
+# include <stdlib.h>
+# include <readline/readline.h>	// readline, rl*
+# include <readline/history.h>	// readline, rl*
+# include <sys/wait.h>			// wait, waitpid, wait3, wait4
+# include <sys/stat.h>			// stat, lstat, fstat
+# include <sys/ioctl.h>			// ioctl
+# include <sys/types.h>			// read
+# include <sys/uio.h>			// read
+# include <signal.h>			// signal, sigaction, sig*, kill
+# include <dirent.h>			// *dir
+# include <string.h>			// strerror
+# include <termios.h>			// tc*
+# include <curses.h>			// tg*
+# include <term.h>				// tg*
+# include <fcntl.h>				// open
+
+#endif


### PR DESCRIPTION
Ajout du fichier minishell.h avec tous les includes des fonctions autorisees (avec commentaires)
Le fichier gitignore a ete modifie en ajoutant le fichier "main.c", pour eviter que nos "main" soient push par accident. Par la suite, lors de la creation du _vrai_ main, il faudra remodifier le fichier gitignore.